### PR TITLE
Adicionei a inicialização do teclado matricial

### DIFF
--- a/inicializar_teclado.c
+++ b/inicializar_teclado.c
@@ -1,0 +1,12 @@
+// Inicialização das GPIOs do teclado
+void inicializar_teclado() {
+  for (int i = 0; i < 4; i++) {
+    gpio_init(linhas[i]);
+    gpio_set_dir(linhas[i], GPIO_OUT);
+    gpio_put(linhas[i], 1); // Inicialmente em HIGH
+
+    gpio_init(colunas[i]);
+    gpio_set_dir(colunas[i], GPIO_IN);
+    gpio_pull_up(colunas[i]); // Habilita pull-up nas colunas
+  }
+}


### PR DESCRIPTION
A função inicializar_teclado()  - inicia as portas GPIO associadas às linhas e colunas do teclado. Inicialmente as linhas são colocadas em nível alto e configuradas como saída. As colunas foram configuradas como entrada com seus respectivos pull-up ativados. Tais configurações permite que a varredura do teclado funcione de forma eficiente.
